### PR TITLE
API_URL setting added

### DIFF
--- a/django_rebel/api/client.py
+++ b/django_rebel/api/client.py
@@ -2,13 +2,14 @@ import requests
 
 
 class Client:
-    API_URL = "https://api.mailgun.net/v3"
+    # API_URL = "https://api.eu.mailgun.net/v3"
 
     def __init__(self, mailgun):
         self.mailgun = mailgun
 
     def prepare_request(self, url: str, method="get", data=None, headers=None, params=None, **kwargs):
-        real_url = "%s/%s/%s" % (self.API_URL, self.mailgun.profile_settings["API"]["DOMAIN"], url)
+        real_url = "%s/%s/%s" % (
+        self.mailgun.profile_settings["API"]["API_URL"], self.mailgun.profile_settings["API"]["DOMAIN"], url)
 
         auth = ("api", self.mailgun.profile_settings["API"]["API_KEY"])
 


### PR DESCRIPTION
Mailgun may have api url such as https://api.eu.mailgun.net/v3 depending on selected region.